### PR TITLE
feat: ts definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 docs
+*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 dist
 docs
-*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -17464,9 +17464,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
-      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+      "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
     },
     "webpack": {
       "version": "4.44.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uint8arrays",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "equals.js",
     "from-string.js",
     "index.js",
-    "to-string.js"
+    "to-string.js",
+    "*.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -28,7 +29,8 @@
     "release": "aegir release --docs",
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
-    "build": "aegir build"
+    "build": "aegir build",
+    "prepublishOnly": "rm *.d.ts && tsc -d --emitDeclarationOnly --allowJs *.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "multibase": "^3.0.0",
-    "web-encoding": "^1.0.2"
+    "web-encoding": "^1.0.4"
   },
   "devDependencies": {
     "aegir": "^25.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,14 @@
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
     "build": "aegir build",
-    "prepublishOnly": "rm *.d.ts && tsc -d --emitDeclarationOnly --allowJs *.js"
+    "prepublishOnly": "rm -f dist/*.d.ts && tsc -d --emitDeclarationOnly --declarationDir dist --allowJs *.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Since you have good JSDoc types it was easy-peasy to generate these. You can regenerate that easily with running `tsc -d --emitDeclarationOnly --allowJs *.js`. `tsc` is already bundled in `aegir`.

Maybe it is worth considering to have this command in `prePublish` hook and generate those upon release? And not polluting the repo?

Closes #3 