### PR TITLE
feat: aegir types generation

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -4,7 +4,7 @@
  * Returns a new Uint8Array created by concatenating the passed ArrayLikes
  *
  * @param {Array<ArrayLike<number>>} arrays
- * @param {Number} length
+ * @param {Number} [length]
  * @returns {Uint8Array}
  */
 function concat (arrays, length) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "Alex Potsides <alex@achingbrain.net>",
   "homepage": "https://github.com/achingbrain/uint8arrays",
   "bugs": "https://github.com/achingbrain/uint8arrays/issues",
+  "types": "dist/src/index.d.ts",
+  "typesVersions": {
+    "*": { "*": ["dist/*", "dist/*/index"] }
+  },
   "files": [
     "compare.js",
     "concat.js",
@@ -28,15 +32,15 @@
     "release": "aegir release --docs",
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
-    "build": "aegir build"
+    "build": "aegir build && aegir ts"
   },
   "license": "MIT",
   "dependencies": {
     "multibase": "^3.0.0",
-    "web-encoding": "^1.0.2"
+    "web-encoding": "^1.0.5"
   },
   "devDependencies": {
-    "aegir": "^25.0.0"
+    "aegir": "^29.2.0"
   },
   "contributors": [
     "achingbrain <alex@achingbrain.net>"

--- a/test/from-string.spec.js
+++ b/test/from-string.spec.js
@@ -8,7 +8,7 @@ const { TextEncoder } = require('web-encoding')
 describe('Uint8Array fromString', () => {
   it('creates a Uint8Array from a string', () => {
     const str = 'hello world'
-    const arr = new TextEncoder('utf8').encode(str)
+    const arr = new TextEncoder().encode(str)
 
     expect(fromString(str)).to.deep.equal(arr)
   })

--- a/test/to-string.spec.js
+++ b/test/to-string.spec.js
@@ -8,7 +8,7 @@ const { TextEncoder } = require('web-encoding')
 describe('Uint8Array toString', () => {
   it('creates a String from a Uint8Array', () => {
     const str = 'hello world'
-    const arr = new TextEncoder('utf8').encode(str)
+    const arr = new TextEncoder().encode(str)
 
     expect(toString(arr)).to.deep.equal(str)
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./node_modules/aegir/src/config/tsconfig.aegir.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+      "test", // remove this line if you don't want to type-check tests
+      "."
+    ]
+}


### PR DESCRIPTION
Minimal updates to add autogenerated typescript types via aegir.
Used this doc to help: https://github.com/ipfs/aegir/blob/master/md/ts-jsdoc.md

I tested this PR locally, linking this to a test project (including updated `web-encoding` dependency) to make sure the types all line up.

See https://github.com/achingbrain/uint8arrays/pull/4#issuecomment-731109567
Resolves #3 

Prerequisite:
- [x] https://github.com/Gozala/web-encoding/issues/12

