### PR TITLE
fix: type mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "author": "Alex Potsides <alex@achingbrain.net>",
   "homepage": "https://github.com/achingbrain/uint8arrays",
   "bugs": "https://github.com/achingbrain/uint8arrays/issues",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
-      "src/*": [
-        "dist/src/*",
-        "dist/src/*/index"
+      "*": [
+        "dist/*",
+        "dist/*/index"
       ]
     }
   },
@@ -51,6 +51,7 @@
   "contributors": [
     "achingbrain <alex@achingbrain.net>",
     "Cayman <caymannava@gmail.com>",
-    "Rafael Ramalho <rafazelramalho19@gmail.com>"
+    "Rafael Ramalho <rafazelramalho19@gmail.com>",
+    "Irakli Gozalishvili <dev@gozala.io>"
   ]
 }


### PR DESCRIPTION
There is no `src` dir which type mappings assumed.