### PR TITLE
feat: export supported string encodings

### DIFF
--- a/from-string.js
+++ b/from-string.js
@@ -4,7 +4,7 @@ const { encoding: getCodec } = require('multibase')
 const utf8Encoder = new TextEncoder()
 
 /**
- * @typedef {import('multibase/src/types').BaseName} BaseName
+ * @typedef {import('multibase/src/types').BaseName | 'utf8' | 'utf-8' | 'ascii' | undefined} SupportedEncodings
  */
 
 /**
@@ -31,7 +31,7 @@ function asciiStringToUint8Array (string) {
  * Also `ascii` which is similar to node's 'binary' encoding.
  *
  * @param {string} string
- * @param {BaseName | 'utf8' | 'utf-8' | 'ascii'} [encoding=utf8] - utf8, base16, base64, base64urlpad, etc
+ * @param {SupportedEncodings} [encoding=utf8] - utf8, base16, base64, base64urlpad, etc
  * @returns {Uint8Array}
  */
 function fromString (string, encoding = 'utf8') {

--- a/to-string.js
+++ b/to-string.js
@@ -4,7 +4,7 @@ const { encoding: getCodec } = require('multibase')
 const utf8Decoder = new TextDecoder('utf8')
 
 /**
- * @typedef {import('multibase/src/types').BaseName} BaseName
+ * @typedef {import('multibase/src/types').BaseName | 'utf8' | 'utf-8' | 'ascii' | undefined} SupportedEncodings
  */
 
 /**
@@ -30,7 +30,7 @@ function uint8ArrayToAsciiString (array) {
  * Also `ascii` which is similar to node's 'binary' encoding.
  *
  * @param {Uint8Array} array - The array to turn into a string
- * @param {BaseName | 'utf8' | 'utf-8' | 'ascii'} [encoding=utf8] - The encoding to use
+ * @param {SupportedEncodings} [encoding=utf8] - The encoding to use
  * @returns {string}
  */
 function toString (array, encoding = 'utf8') {


### PR DESCRIPTION
To make consuming the types of this module easier, export the list of supported to/from string encodings