### PR TITLE
chore: add benchmarks for to-string

### DIFF
--- a/benchmarks/to-string.js
+++ b/benchmarks/to-string.js
@@ -40,29 +40,29 @@ function utf8ReadFromCharCode (buffer, start, end) {
 }
 
 // https://github.com/achingbrain/uint8arrays/issues/30#issuecomment-1199120924
-function utf8ReadConcat(buffer, start, end) {
+function utf8ReadConcat (buffer, start, end) {
   if (end - start < 1) {
-      return "";
+    return ''
   }
 
-  var str = "";
-  for (var i = start; i < end;) {
-      var t = buffer[i++];
-      if (t <= 0x7F) {
-          str += String.fromCharCode(t);
-      } else if (t >= 0xC0 && t < 0xE0) {
-          str += String.fromCharCode((t & 0x1F) << 6 | buffer[i++] & 0x3F);
-      } else if (t >= 0xE0 && t < 0xF0) {
-          str += String.fromCharCode((t & 0xF) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F);
-      } else if (t >= 0xF0) {
-          var t2 = ((t & 7) << 18 | (buffer[i++] & 0x3F) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F) - 0x10000;
-          str += String.fromCharCode(0xD800 + (t2 >> 10));
-          str += String.fromCharCode(0xDC00 + (t2 & 0x3FF));
-      }
+  let str = ''
+  for (let i = start; i < end;) {
+    const t = buffer[i++]
+    if (t <= 0x7F) {
+      str += String.fromCharCode(t)
+    } else if (t >= 0xC0 && t < 0xE0) {
+      str += String.fromCharCode((t & 0x1F) << 6 | buffer[i++] & 0x3F)
+    } else if (t >= 0xE0 && t < 0xF0) {
+      str += String.fromCharCode((t & 0xF) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F)
+    } else if (t >= 0xF0) {
+      const t2 = ((t & 7) << 18 | (buffer[i++] & 0x3F) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F) - 0x10000
+      str += String.fromCharCode(0xD800 + (t2 >> 10))
+      str += String.fromCharCode(0xDC00 + (t2 & 0x3FF))
+    }
   }
 
-  return str;
-};
+  return str
+}
 
 const suite = new Benchmark.Suite()
 

--- a/benchmarks/to-string.js
+++ b/benchmarks/to-string.js
@@ -7,7 +7,6 @@ $ npx playwright-test benchmarks/to-string.js --runner benchmark
 
 import Benchmark from 'benchmark'
 import { fromString } from '../src/from-string.js'
-import { toString } from '../src/to-string.js'
 
 const string = 'Hello world, this is a Uint8Array created from a string'
 const DATA = fromString(string)
@@ -42,8 +41,8 @@ function utf8Read (buffer, start, end) {
 const suite = new Benchmark.Suite()
 
 suite
-  .add('toString', () => {
-    const res = toString(DATA)
+  .add('TextDecoder', () => {
+    const res = new TextDecoder().decode(DATA)
 
     if (res !== string) {
       throw new Error('String encoding failed')
@@ -51,7 +50,7 @@ suite
   })
   .add('Buffer.toString', function () {
     if (globalThis.Buffer == null) {
-      return
+      throw new Error('Buffer is not available')
     }
 
     const buf = globalThis.Buffer.from(DATA.buffer, DATA.byteOffset, DATA.byteLength)

--- a/benchmarks/to-string.js
+++ b/benchmarks/to-string.js
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+
+/*
+$ node benchmarks/to-string.js
+$ npx playwright-test benchmarks/to-string.js --runner benchmark
+*/
+
+import Benchmark from 'benchmark'
+import { fromString } from '../src/from-string.js'
+import { toString } from '../src/to-string.js'
+
+const string = 'Hello world, this is a Uint8Array created from a string'
+const DATA = fromString(string)
+
+// https://github.com/achingbrain/uint8arrays/issues/30#issuecomment-1199120924
+function utf8Read (buffer, start, end) {
+  const len = end - start
+  if (len < 1) { return '' }
+  let parts = null
+  const chunk = []
+  let i = 0 // char offset
+  let t // temporary
+  while (start < end) {
+    t = buffer[start++]
+    if (t < 128) { chunk[i++] = t } else if (t > 191 && t < 224) { chunk[i++] = (t & 31) << 6 | buffer[start++] & 63 } else if (t > 239 && t < 365) {
+      t = ((t & 7) << 18 | (buffer[start++] & 63) << 12 | (buffer[start++] & 63) << 6 | buffer[start++] & 63) - 0x10000
+      chunk[i++] = 0xD800 + (t >> 10)
+      chunk[i++] = 0xDC00 + (t & 1023)
+    } else { chunk[i++] = (t & 15) << 12 | (buffer[start++] & 63) << 6 | buffer[start++] & 63 }
+    if (i > 8191) {
+      (parts || (parts = [])).push(String.fromCharCode.apply(String, chunk))
+      i = 0
+    }
+  }
+  if (parts) {
+    if (i) { parts.push(String.fromCharCode.apply(String, chunk.slice(0, i))) }
+    return parts.join('')
+  }
+  return String.fromCharCode.apply(String, chunk.slice(0, i))
+}
+
+const suite = new Benchmark.Suite()
+
+suite
+  .add('toString', () => {
+    const res = toString(DATA)
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
+  .add('Buffer.toString', function () {
+    if (globalThis.Buffer == null) {
+      return
+    }
+
+    const buf = globalThis.Buffer.from(DATA.buffer, DATA.byteOffset, DATA.byteLength)
+    const res = buf.toString('utf8')
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
+  .add('utf8Read', () => {
+    const res = utf8Read(DATA, 0, DATA.byteLength)
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
+  // add listeners
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  // run async
+  .run({ async: true })

--- a/benchmarks/to-string.js
+++ b/benchmarks/to-string.js
@@ -48,18 +48,6 @@ suite
       throw new Error('String encoding failed')
     }
   })
-  .add('Buffer.toString', function () {
-    if (globalThis.Buffer == null) {
-      throw new Error('Buffer is not available')
-    }
-
-    const buf = globalThis.Buffer.from(DATA.buffer, DATA.byteOffset, DATA.byteLength)
-    const res = buf.toString('utf8')
-
-    if (res !== string) {
-      throw new Error('String encoding failed')
-    }
-  })
   .add('utf8Read', () => {
     const res = utf8Read(DATA, 0, DATA.byteLength)
 
@@ -67,6 +55,19 @@ suite
       throw new Error('String encoding failed')
     }
   })
+
+if (globalThis.Buffer != null) {
+  suite.add('Buffer.toString', function () {
+    const buf = globalThis.Buffer.from(DATA.buffer, DATA.byteOffset, DATA.byteLength)
+    const res = buf.toString('utf8')
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
+}
+
+suite
   // add listeners
   .on('cycle', (event) => {
     console.log(String(event.target))

--- a/benchmarks/to-string.js
+++ b/benchmarks/to-string.js
@@ -7,12 +7,13 @@ $ npx playwright-test benchmarks/to-string.js --runner benchmark
 
 import Benchmark from 'benchmark'
 import { fromString } from '../src/from-string.js'
+import { toString } from '../src/to-string.js'
 
 const string = 'Hello world, this is a Uint8Array created from a string'
 const DATA = fromString(string)
 
 // https://github.com/achingbrain/uint8arrays/issues/30#issuecomment-1199120924
-function utf8Read (buffer, start, end) {
+function utf8ReadFromCharCode (buffer, start, end) {
   const len = end - start
   if (len < 1) { return '' }
   let parts = null
@@ -38,9 +39,41 @@ function utf8Read (buffer, start, end) {
   return String.fromCharCode.apply(String, chunk.slice(0, i))
 }
 
+// https://github.com/achingbrain/uint8arrays/issues/30#issuecomment-1199120924
+function utf8ReadConcat(buffer, start, end) {
+  if (end - start < 1) {
+      return "";
+  }
+
+  var str = "";
+  for (var i = start; i < end;) {
+      var t = buffer[i++];
+      if (t <= 0x7F) {
+          str += String.fromCharCode(t);
+      } else if (t >= 0xC0 && t < 0xE0) {
+          str += String.fromCharCode((t & 0x1F) << 6 | buffer[i++] & 0x3F);
+      } else if (t >= 0xE0 && t < 0xF0) {
+          str += String.fromCharCode((t & 0xF) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F);
+      } else if (t >= 0xF0) {
+          var t2 = ((t & 7) << 18 | (buffer[i++] & 0x3F) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F) - 0x10000;
+          str += String.fromCharCode(0xD800 + (t2 >> 10));
+          str += String.fromCharCode(0xDC00 + (t2 & 0x3FF));
+      }
+  }
+
+  return str;
+};
+
 const suite = new Benchmark.Suite()
 
 suite
+  .add('Uint8Arrays.toString', () => {
+    const res = toString(DATA)
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
   .add('TextDecoder', () => {
     const res = new TextDecoder().decode(DATA)
 
@@ -48,8 +81,15 @@ suite
       throw new Error('String encoding failed')
     }
   })
-  .add('utf8Read', () => {
-    const res = utf8Read(DATA, 0, DATA.byteLength)
+  .add('utf8ReadFromCharCode', () => {
+    const res = utf8ReadFromCharCode(DATA, 0, DATA.byteLength)
+
+    if (res !== string) {
+      throw new Error('String encoding failed')
+    }
+  })
+  .add('utf8ReadConcat', () => {
+    const res = utf8ReadConcat(DATA, 0, DATA.byteLength)
 
     if (res !== string) {
       throw new Error('String encoding failed')

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "multiformats": "^9.4.2"
   },
   "devDependencies": {
+    "@types/benchmark": "^2.1.1",
     "aegir": "^35.0.0",
+    "benchmark": "^2.1.4",
     "util": "^0.12.4"
   },
   "eslintConfig": {


### PR DESCRIPTION
Adds benchmarks to compare various stringification methods

Node:

```console
$ node benchmarks/to-string.js                                     
Uint8Arrays.toString x 349,476 ops/sec ±2.40% (82 runs sampled)
TextDecoder x 363,460 ops/sec ±3.77% (64 runs sampled)
utf8ReadFromCharCode x 1,833,389 ops/sec ±0.82% (90 runs sampled)
utf8ReadConcat x 1,182,950 ops/sec ±0.39% (89 runs sampled)
Buffer.toString x 3,322,147 ops/sec ±0.53% (87 runs sampled)
Fastest is Buffer.toString
```

Chrome:

```console
$ npx playwright-test benchmarks/to-string.js --runner benchmark
✔ chromium set up
Uint8Arrays.toString x 1,245,619 ops/sec ±2.81% (63 runs sampled)
TextDecoder x 1,660,401 ops/sec ±1.62% (60 runs sampled)
utf8ReadFromCharCode x 2,867,464 ops/sec ±0.34% (67 runs sampled)
utf8ReadConcat x 1,737,527 ops/sec ±0.24% (68 runs sampled)
Fastest is utf8ReadFromCharCode
```

Firefox:

```console
$ npx playwright-test benchmarks/to-string.js --runner benchmark --browser firefox 
✔ firefox set up
Uint8Arrays.toString x 1,662,562 ops/sec ±5.23% (60 runs sampled)
TextDecoder x 1,774,664 ops/sec ±7.01% (61 runs sampled)
utf8ReadFromCharCode x 1,324,124 ops/sec ±1.44% (64 runs sampled)
utf8ReadConcat x 769,512 ops/sec ±31.15% (32 runs sampled)
Fastest is TextDecoder
```