### PR TITLE
chore: add concat benchmark

### DIFF
--- a/benchmarks/concat.js
+++ b/benchmarks/concat.js
@@ -1,0 +1,84 @@
+/* eslint-disable no-console */
+
+/*
+$ node benchmarks/to-string.js
+$ npx playwright-test benchmarks/to-string.js --runner benchmark
+*/
+
+import Benchmark from 'benchmark'
+import { fromString } from '../src/from-string.js'
+import { concat } from '../src/concat.js'
+import { allocUnsafe } from '../src/alloc.js'
+
+const string = 'Hello world, this is a Uint8Array created from a string'
+const DATA1 = fromString(string)
+const DATA2 = fromString(string)
+
+function checkConcat (arr) {
+  if (arr.byteLength !== (DATA1.byteLength + DATA2.byteLength)) {
+    return false
+  }
+
+  for (let i = 0; i < arr.byteLength; i++) {
+    let offset = i
+    let bytes = DATA1
+
+    if (offset > bytes.byteLength) {
+      offset -= bytes.byteLength
+      bytes = DATA2
+    }
+
+    if (arr[i] !== bytes[offset]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+const suite = new Benchmark.Suite()
+
+suite
+  .add('Uint8Arrays.concat', () => {
+    const res = concat([DATA1, DATA2])
+
+    if (checkConcat(res)) {
+      throw new Error('Concat failed')
+    }
+  })
+  .add('Uint8Arrays.concat with length', () => {
+    const res = concat([DATA1, DATA2], DATA1.byteLength + DATA2.byteLength)
+
+    if (checkConcat(res)) {
+      throw new Error('Concat failed')
+    }
+  })
+  .add('Uint8Array.set', () => {
+    const res = new Uint8Array(DATA1.byteLength + DATA2.byteLength)
+    res.set(DATA1, 0)
+    res.set(DATA2, DATA1.byteLength)
+
+    if (checkConcat(res)) {
+      throw new Error('Concat failed')
+    }
+  })
+  .add('allocUnsafe.set', () => {
+    const res = allocUnsafe(DATA1.byteLength + DATA2.byteLength)
+    res.set(DATA1, 0)
+    res.set(DATA2, DATA1.byteLength)
+
+    if (checkConcat(res)) {
+      throw new Error('Concat failed')
+    }
+  })
+
+suite
+  // add listeners
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  // run async
+  .run({ async: true })


### PR DESCRIPTION
Node:

```console
% node benchmarks/concat.js                                  
Uint8Arrays.concat x 976,639 ops/sec ±1.25% (89 runs sampled)
Uint8Arrays.concat with length x 977,493 ops/sec ±1.23% (88 runs sampled)
Uint8Array.set x 1,032,854 ops/sec ±1.12% (90 runs sampled)
allocUnsafe.set x 1,669,431 ops/sec ±0.89% (88 runs sampled)
Fastest is allocUnsafe.set
```

Chrome:

```console
% npx playwright-test benchmarks/concat.js --runner benchmark        
✔ chromium set up
Uint8Arrays.concat x 1,480,606 ops/sec ±0.83% (65 runs sampled)
Uint8Arrays.concat with length x 1,400,113 ops/sec ±0.43% (68 runs sampled)
Uint8Array.set x 1,504,864 ops/sec ±0.45% (65 runs sampled)
allocUnsafe.set x 994,716 ops/sec ±0.55% (67 runs sampled)
Fastest is Uint8Array.set
```

Firefox:

```console
% npx playwright-test benchmarks/concat.js --runner benchmark --browser firefox
✔ firefox set up
Uint8Arrays.concat x 2,440,034 ops/sec ±0.17% (68 runs sampled)
Uint8Arrays.concat with length x 2,413,513 ops/sec ±1.58% (64 runs sampled)
Uint8Array.set x 2,434,228 ops/sec ±1.50% (65 runs sampled)
allocUnsafe.set x 1,502,430 ops/sec ±2.02% (64 runs sampled)
Fastest is Uint8Arrays.concat,Uint8Array.set
```
