### PR TITLE
fix: use allocUnsafe where possible

### DIFF
--- a/src/concat.js
+++ b/src/concat.js
@@ -1,3 +1,5 @@
+import { allocUnsafe } from './alloc.js'
+
 /**
  * Returns a new Uint8Array created by concatenating the passed ArrayLikes
  *
@@ -9,7 +11,7 @@ export function concat (arrays, length) {
     length = arrays.reduce((acc, curr) => acc + curr.length, 0)
   }
 
-  const output = new Uint8Array(length)
+  const output = allocUnsafe(length)
   let offset = 0
 
   for (const arr of arrays) {

--- a/src/util/bases.js
+++ b/src/util/bases.js
@@ -1,4 +1,5 @@
 import { bases } from 'multiformats/basics'
+import { allocUnsafe } from '../alloc.js'
 
 /**
  * @typedef {import('multiformats/bases/interface').MultibaseCodec<any>} MultibaseCodec
@@ -43,7 +44,7 @@ const ascii = createCodec('ascii', 'a', (buf) => {
   return string
 }, (str) => {
   str = str.substring(1)
-  const buf = new Uint8Array(str.length)
+  const buf = allocUnsafe(str.length)
 
   for (let i = 0; i < str.length; i++) {
     buf[i] = str.charCodeAt(i)

--- a/src/xor.js
+++ b/src/xor.js
@@ -1,3 +1,5 @@
+import { allocUnsafe } from './alloc.js'
+
 /**
  * Returns the xor distance between two arrays
  *
@@ -9,7 +11,7 @@ export function xor (a, b) {
     throw new Error('Inputs should have the same length')
   }
 
-  const result = new Uint8Array(a.length)
+  const result = allocUnsafe(a.length)
 
   for (let i = 0; i < a.length; i++) {
     result[i] = a[i] ^ b[i]


### PR DESCRIPTION
Before:

```
Uint8Arrays.concat with length x 970,746 ops/sec ±1.19% (91 runs sampled)
```

After:

```
Uint8Arrays.concat with length x 1,688,327 ops/sec ±0.90% (87 runs sampled)
```