### PR TITLE
fix: use Buffer.from for stringification where available

### DIFF
--- a/src/from-string.js
+++ b/src/from-string.js
@@ -22,6 +22,10 @@ export function fromString (string, encoding = 'utf8') {
     throw new Error(`Unsupported encoding "${encoding}"`)
   }
 
+  if ((encoding === 'utf8' || encoding === 'utf-8') && globalThis.Buffer != null && globalThis.Buffer.from != null) {
+    return globalThis.Buffer.from(string, 'utf8')
+  }
+
   // add multibase prefix
   return base.decoder.decode(`${base.prefix}${string}`)
 }

--- a/src/to-string.js
+++ b/src/to-string.js
@@ -22,6 +22,10 @@ export function toString (array, encoding = 'utf8') {
     throw new Error(`Unsupported encoding "${encoding}"`)
   }
 
+  if ((encoding === 'utf8' || encoding === 'utf-8') && globalThis.Buffer != null && globalThis.Buffer.from != null) {
+    return globalThis.Buffer.from(array.buffer, array.byteOffset, array.byteLength).toString('utf8')
+  }
+
   // strip multibase prefix
   return base.encoder.encode(array).substring(1)
 }

--- a/src/util/bases.js
+++ b/src/util/bases.js
@@ -37,7 +37,7 @@ const string = createCodec('utf8', 'u', (buf) => {
   str = str.substring(1)
 
   if (globalThis.Buffer != null && globalThis.Buffer.from != null) {
-    return globalThis.Buffer.from(str)
+    return globalThis.Buffer.from(str, 'utf8')
   }
 
   const encoder = new TextEncoder()

--- a/src/util/bases.js
+++ b/src/util/bases.js
@@ -27,21 +27,11 @@ function createCodec (name, prefix, encode, decode) {
 }
 
 const string = createCodec('utf8', 'u', (buf) => {
-  if (globalThis.Buffer != null && globalThis.Buffer.from != null) {
-    return 'u' + globalThis.Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('utf8')
-  }
-
   const decoder = new TextDecoder('utf8')
   return 'u' + decoder.decode(buf)
 }, (str) => {
-  str = str.substring(1)
-
-  if (globalThis.Buffer != null && globalThis.Buffer.from != null) {
-    return globalThis.Buffer.from(str, 'utf8')
-  }
-
   const encoder = new TextEncoder()
-  return encoder.encode(str)
+  return encoder.encode(str.substring(1))
 })
 
 const ascii = createCodec('ascii', 'a', (buf) => {

--- a/src/util/bases.js
+++ b/src/util/bases.js
@@ -27,11 +27,21 @@ function createCodec (name, prefix, encode, decode) {
 }
 
 const string = createCodec('utf8', 'u', (buf) => {
+  if (globalThis.Buffer != null && globalThis.Buffer.from != null) {
+    return 'u' + globalThis.Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('utf8')
+  }
+
   const decoder = new TextDecoder('utf8')
   return 'u' + decoder.decode(buf)
 }, (str) => {
+  str = str.substring(1)
+
+  if (globalThis.Buffer != null && globalThis.Buffer.from != null) {
+    return globalThis.Buffer.from(str)
+  }
+
   const encoder = new TextEncoder()
-  return encoder.encode(str.substring(1))
+  return encoder.encode(str)
 })
 
 const ascii = createCodec('ascii', 'a', (buf) => {


### PR DESCRIPTION
Before:

```
Uint8Arrays.fromString x 1,203,638 ops/sec ±1.53% (85 runs sampled)
Uint8Arrays.toString x 376,183 ops/sec ±2.20% (74 runs sampled)
```

After:

```
Uint8Arrays.fromString x 2,051,032 ops/sec ±0.54% (88 runs sampled)
Uint8Arrays.toString x 2,912,464 ops/sec ±0.38% (91 runs sampled)
```