### PR TITLE
fix: export SupportedEncodings from to-string and from-string

### DIFF
--- a/src/from-string.ts
+++ b/src/from-string.ts
@@ -1,6 +1,8 @@
 import bases, { SupportedEncodings } from './util/bases.js'
 import { asUint8Array } from './util/as-uint8array.js'
 
+export type { SupportedEncodings }
+
 /**
  * Create a `Uint8Array` from the passed string
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,5 @@ export {
   toString,
   xor
 }
+
+export type { SupportedEncodings } from './util/bases.js'

--- a/src/to-string.ts
+++ b/src/to-string.ts
@@ -1,8 +1,6 @@
 import bases, { SupportedEncodings } from './util/bases.js'
 
-/**
- * @typedef {import('./util/bases').SupportedEncodings} SupportedEncodings
- */
+export type { SupportedEncodings }
 
 /**
  * Turns a `Uint8Array` into a string.

--- a/test/from-string.spec.ts
+++ b/test/from-string.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { fromString } from '../src/from-string.js'
+import { fromString, SupportedEncodings } from '../src/from-string.js'
 import { toString } from '../src/to-string.js'
-import bases, { SupportedEncodings } from '../src/util/bases.js'
+import bases from '../src/util/bases.js'
 
 const supportedBases = Object.keys(bases) as SupportedEncodings[]
 


### PR DESCRIPTION
Restore previous type export