### PR TITLE
docs: Remove duplicate content section in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 $ npm i uint8arrays
 ```
 
-=======
 ### Browser `<script>` tag
 
 Loading this module through a script tag will make it's exports available as `Uint8arrays` in the global namespace.

--- a/README.md
+++ b/README.md
@@ -34,27 +34,6 @@
 $ npm i uint8arrays
 ```
 
-- [Install](#install)
-- [API](#api)
-  - [alloc(size)](#allocsize)
-    - [Example](#example)
-  - [allocUnsafe(size)](#allocunsafesize)
-    - [Example](#example-1)
-  - [compare(a, b)](#comparea-b)
-    - [Example](#example-2)
-  - [concat(arrays, \[length])](#concatarrays-length)
-    - [Example](#example-3)
-  - [equals(a, b)](#equalsa-b)
-    - [Example](#example-4)
-  - [fromString(string, encoding = 'utf8')](#fromstringstring-encoding--utf8)
-    - [Example](#example-5)
-  - [toString(array, encoding = 'utf8')](#tostringarray-encoding--utf8)
-    - [Example](#example-6)
-  - [xor(a, b)](#xora-b)
-    - [Example](#example-7)
-- [License](#license)
-- [Contribute](#contribute)
-
 ## API
 
 ### alloc(size)


### PR DESCRIPTION
This PR simply removes the duplicate contents list that exists under the `Install` section.