### PR TITLE
fix: use Buffer.concat on node as it is faster

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -2,6 +2,10 @@
  * Can be used with Array.sort to sort and array with Uint8Array entries
  */
 export function compare (a: Uint8Array, b: Uint8Array): number {
+  if (globalThis.Buffer != null) {
+    return globalThis.Buffer.compare(a, b)
+  }
+
   for (let i = 0; i < a.byteLength; i++) {
     if (a[i] < b[i]) {
       return -1

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -4,7 +4,11 @@ import { asUint8Array } from './util/as-uint8array.js'
 /**
  * Returns a new Uint8Array created by concatenating the passed ArrayLikes
  */
-export function concat (arrays: Array<ArrayLike<number>>, length?: number): Uint8Array {
+export function concat (arrays: Uint8Array[], length?: number): Uint8Array {
+  if (globalThis.Buffer != null) {
+    return asUint8Array(globalThis.Buffer.concat(arrays, length))
+  }
+
   if (length == null) {
     length = arrays.reduce((acc, curr) => acc + curr.length, 0)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@
  *
  * ## concat(arrays, \[length])
  *
- * Concatenate one or more array-likes and return a `Uint8Array` with their contents.
+ * Concatenate one or more `Uint8Array`s and return a `Uint8Array` with their contents.
  *
  * If you know the length of the arrays, pass it as a second parameter, otherwise it will be calculated by traversing the list of arrays.
  *

--- a/test/concat.spec.ts
+++ b/test/concat.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
+import { alloc } from '../src/alloc.js'
 import { concat } from '../src/concat.js'
 
 describe('Uint8Array concat', () => {
@@ -20,25 +21,9 @@ describe('Uint8Array concat', () => {
     expect(concat([a, b], 8)).to.deep.equal(c)
   })
 
-  it('concats mixed Uint8Arrays and Arrays', () => {
-    const a = Uint8Array.from([0, 1, 2, 3])
-    const b = [4, 5, 6, 7]
-    const c = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])
-
-    expect(concat([a, b])).to.deep.equal(c)
-  })
-
-  it('concats mixed Uint8Arrays and Arrays with a length', () => {
-    const a = Uint8Array.from([0, 1, 2, 3])
-    const b = [4, 5, 6, 7]
-    const c = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])
-
-    expect(concat([a, b], 8)).to.deep.equal(c)
-  })
-
   it('concat returns Uint8Array', () => {
     const a = Uint8Array.from([0, 1, 2, 3])
-    const b = [4, 5, 6, 7]
+    const b = alloc(10).fill(1)
     const c = concat([a, b])
     const slice = c.slice()
 


### PR DESCRIPTION
Running the concat.js benchmark:

Before:

```
Uint8Arrays.concat x 792,619 ops/sec ±0.67% (98 runs sampled)
Uint8Arrays.concat with length x 782,264 ops/sec ±0.18% (98 runs sampled)
Uint8Array.set x 799,528 ops/sec ±0.67% (92 runs sampled)
allocUnsafe.set x 851,403 ops/sec ±0.24% (97 runs sampled)
Fastest is allocUnsafe.set
```

After:

```
Uint8Arrays.concat x 896,831 ops/sec ±0.20% (101 runs sampled)
Uint8Arrays.concat with length x 887,523 ops/sec ±0.19% (99 runs sampled)
Uint8Array.set x 814,749 ops/sec ±0.46% (98 runs sampled)
allocUnsafe.set x 885,140 ops/sec ±0.28% (98 runs sampled)
Fastest is Uint8Arrays.concat
```