### PR TITLE
fix: revert use of buffer.concat on node.js

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -4,11 +4,7 @@ import { asUint8Array } from './util/as-uint8array.js'
 /**
  * Returns a new Uint8Array created by concatenating the passed ArrayLikes
  */
-export function concat (arrays: Uint8Array[], length?: number): Uint8Array {
-  if (globalThis.Buffer != null) {
-    return asUint8Array(globalThis.Buffer.concat(arrays, length))
-  }
-
+export function concat (arrays: Array<ArrayLike<number>>, length?: number): Uint8Array {
   if (length == null) {
     length = arrays.reduce((acc, curr) => acc + curr.length, 0)
   }

--- a/test/concat.spec.ts
+++ b/test/concat.spec.ts
@@ -21,6 +21,22 @@ describe('Uint8Array concat', () => {
     expect(concat([a, b], 8)).to.deep.equal(c)
   })
 
+  it('concats mixed Uint8Arrays and Arrays', () => {
+    const a = Uint8Array.from([0, 1, 2, 3])
+    const b = [4, 5, 6, 7]
+    const c = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])
+
+    expect(concat([a, b])).to.deep.equal(c)
+  })
+
+  it('concats mixed Uint8Arrays and Arrays with a length', () => {
+    const a = Uint8Array.from([0, 1, 2, 3])
+    const b = [4, 5, 6, 7]
+    const c = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])
+
+    expect(concat([a, b], 8)).to.deep.equal(c)
+  })
+
   it('concat returns Uint8Array', () => {
     const a = Uint8Array.from([0, 1, 2, 3])
     const b = alloc(10).fill(1)


### PR DESCRIPTION
4.0.9 had a breaking change - the input type of `concat` stopped accepting plain arrays, requiring an array of `Uint8Array`s.