### PR TITLE
fix!: return ArrayBuffer-backed arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
   },
   "devDependencies": {
     "@types/benchmark": "^2.1.1",
-    "aegir": "^47.1.5",
+    "aegir": "^48.0.1",
     "benchmark": "^2.1.4"
   },
   "imports": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "multiformats": "^13.0.0"
+    "multiformats": "^14.0.0"
   },
   "devDependencies": {
     "@types/benchmark": "^2.1.1",

--- a/src/alloc.node.ts
+++ b/src/alloc.node.ts
@@ -5,7 +5,7 @@ import { asUint8Array } from '#util/as-uint8array'
  * Returns a `Uint8Array` of the requested size. Referenced memory will
  * be initialized to 0.
  */
-export function alloc (size: number = 0): Uint8Array {
+export function alloc (size: number = 0): Uint8Array<ArrayBuffer> {
   return asUint8Array(Buffer.alloc(size))
 }
 
@@ -14,6 +14,6 @@ export function alloc (size: number = 0): Uint8Array {
  * uninitialized memory. Only use if you are certain you will immediately
  * overwrite every value in the returned `Uint8Array`.
  */
-export function allocUnsafe (size: number = 0): Uint8Array {
+export function allocUnsafe (size: number = 0): Uint8Array<ArrayBuffer> {
   return asUint8Array(Buffer.allocUnsafe(size))
 }

--- a/src/alloc.ts
+++ b/src/alloc.ts
@@ -2,7 +2,7 @@
  * Returns a `Uint8Array` of the requested size. Referenced memory will
  * be initialized to 0.
  */
-export function alloc (size: number = 0): Uint8Array {
+export function alloc (size: number = 0): Uint8Array<ArrayBuffer> {
   return new Uint8Array(size)
 }
 
@@ -11,6 +11,6 @@ export function alloc (size: number = 0): Uint8Array {
  * uninitialized memory. Only use if you are certain you will immediately
  * overwrite every value in the returned `Uint8Array`.
  */
-export function allocUnsafe (size: number = 0): Uint8Array {
+export function allocUnsafe (size: number = 0): Uint8Array<ArrayBuffer> {
   return new Uint8Array(size)
 }

--- a/src/concat.node.ts
+++ b/src/concat.node.ts
@@ -4,6 +4,6 @@ import { asUint8Array } from '#util/as-uint8array'
 /**
  * Returns a new Uint8Array created by concatenating the passed Uint8Arrays
  */
-export function concat (arrays: Uint8Array[], length?: number): Uint8Array {
+export function concat (arrays: Uint8Array[], length?: number): Uint8Array<ArrayBuffer> {
   return asUint8Array(Buffer.concat(arrays, length))
 }

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -4,7 +4,7 @@ import { asUint8Array } from '#util/as-uint8array'
 /**
  * Returns a new Uint8Array created by concatenating the passed Uint8Arrays
  */
-export function concat (arrays: Uint8Array[], length?: number): Uint8Array {
+export function concat (arrays: Uint8Array[], length?: number): Uint8Array<ArrayBuffer> {
   if (length == null) {
     length = arrays.reduce((acc, curr) => acc + curr.length, 0)
   }

--- a/src/from-string.node.ts
+++ b/src/from-string.node.ts
@@ -12,7 +12,7 @@ export type { SupportedEncodings }
  *
  * Also `ascii` which is similar to node's 'binary' encoding.
  */
-export function fromString (string: string, encoding: SupportedEncodings = 'utf8'): Uint8Array {
+export function fromString (string: string, encoding: SupportedEncodings = 'utf8'): Uint8Array<ArrayBuffer> {
   const base = bases[encoding]
 
   if (base == null) {

--- a/src/from-string.ts
+++ b/src/from-string.ts
@@ -10,7 +10,7 @@ export type { SupportedEncodings }
  *
  * Also `ascii` which is similar to node's 'binary' encoding.
  */
-export function fromString (string: string, encoding: SupportedEncodings = 'utf8'): Uint8Array {
+export function fromString (string: string, encoding: SupportedEncodings = 'utf8'): Uint8Array<ArrayBuffer> {
   const base = bases[encoding]
 
   if (base == null) {

--- a/src/util/as-uint8array.node.ts
+++ b/src/util/as-uint8array.node.ts
@@ -2,6 +2,12 @@
  * To guarantee Uint8Array semantics, convert nodejs Buffers
  * into vanilla Uint8Arrays
  */
-export function asUint8Array (buf: Uint8Array): Uint8Array {
-  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+export function asUint8Array (buf: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (buf.buffer instanceof ArrayBuffer) {
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+  }
+
+  let b = buf.slice()
+
+  return new Uint8Array(b.buffer, 0, b.byteLength)
 }

--- a/src/util/as-uint8array.node.ts
+++ b/src/util/as-uint8array.node.ts
@@ -7,7 +7,7 @@ export function asUint8Array (buf: Uint8Array): Uint8Array<ArrayBuffer> {
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
   }
 
-  let b = buf.slice()
+  const b = buf.slice()
 
   return new Uint8Array(b.buffer, 0, b.byteLength)
 }

--- a/src/util/as-uint8array.ts
+++ b/src/util/as-uint8array.ts
@@ -1,7 +1,17 @@
+function isByteArrayWithArrayBuffer (b?: Uint8Array): b is Uint8Array<ArrayBuffer> {
+  return b?.buffer instanceof ArrayBuffer
+}
+
 /**
  * To guarantee Uint8Array semantics, convert nodejs Buffers
  * into vanilla Uint8Arrays
  */
-export function asUint8Array (buf: Uint8Array): Uint8Array {
-  return buf
+export function asUint8Array (buf: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (isByteArrayWithArrayBuffer(buf)) {
+    return buf
+  }
+
+  let b = buf.slice()
+
+  return new Uint8Array(b.buffer, 0, b.byteLength)
 }

--- a/src/util/as-uint8array.ts
+++ b/src/util/as-uint8array.ts
@@ -11,7 +11,7 @@ export function asUint8Array (buf: Uint8Array): Uint8Array<ArrayBuffer> {
     return buf
   }
 
-  let b = buf.slice()
+  const b = buf.slice()
 
   return new Uint8Array(b.buffer, 0, b.byteLength)
 }

--- a/src/util/bases.ts
+++ b/src/util/bases.ts
@@ -2,7 +2,7 @@ import { bases } from 'multiformats/basics'
 import type { MultibaseCodec } from 'multiformats'
 import { allocUnsafe } from '#alloc'
 
-function createCodec (name: string, prefix: string, encode: (buf: Uint8Array) => string, decode: (str: string) => Uint8Array): MultibaseCodec<any> {
+function createCodec (name: string, prefix: string, encode: (buf: Uint8Array) => string, decode: (str: string) => Uint8Array<ArrayBuffer>): MultibaseCodec<any> {
   return {
     name,
     prefix,

--- a/src/xor.ts
+++ b/src/xor.ts
@@ -4,7 +4,7 @@ import { asUint8Array } from '#util/as-uint8array'
 /**
  * Returns the xor distance between two Uint8Arrays
  */
-export function xor (a: Uint8Array, b: Uint8Array): Uint8Array {
+export function xor (a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer> {
   if (a.length !== b.length) {
     throw new Error('Inputs should have the same length')
   }

--- a/test/equals.spec.ts
+++ b/test/equals.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { equals } from '../src/equals.js'
+import { equals } from '../src/equals.ts'
 
 describe('Uint8Array equals', () => {
   it('finds two Uint8Arrays equal', () => {

--- a/test/from-string.spec.ts
+++ b/test/from-string.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import bases from '../src/util/bases.js'
+import bases from '../src/util/bases.ts'
 import type { SupportedEncodings } from '#from-string'
 import { fromString } from '#from-string'
 import { toString } from '#to-string'

--- a/test/xor-compare.spec.ts
+++ b/test/xor-compare.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { xorCompare } from '../src/xor-compare.js'
+import { xorCompare } from '../src/xor-compare.ts'
 
 describe('xor-compare', () => {
   it('compare', () => {

--- a/test/xor.spec.ts
+++ b/test/xor.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { xor } from '../src/xor.js'
+import { xor } from '../src/xor.ts'
 
 describe('Uint8Array xor', () => {
   it('xors 1,0 and 0,1', () => {


### PR DESCRIPTION
Since https://github.com/microsoft/TypeScript/pull/59417 `Uint8Array`s backed by `ArrayBuffer` are incompatible with those backed with `SharedArrayBuffer` so be explicit about the types returned.

BREAKING CHANGE: where `Uint8Array` was returned, now `Uint8Array<ArrayBuffer>`is returned instead