### PR TITLE
feat: add withArrayBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Since Node.js `Buffer`s are also `Uint8Array`s, it falls back to `Buffer` intern
 
 Create a new `Uint8Array`. When running under Node.js, `Buffer` will be used in preference to `Uint8Array`.
 
-## Example
+### Example
 
 ```ts
 import { alloc } from 'uint8arrays/alloc'
@@ -46,7 +46,7 @@ Create a new `Uint8Array`. When running under Node.js, `Buffer` will be used in 
 
 On platforms that support it, memory referenced by the returned `Uint8Array` will not be initialized.
 
-## Example
+### Example
 
 ```ts
 import { allocUnsafe } from 'uint8arrays/alloc'
@@ -58,7 +58,7 @@ const buf = allocUnsafe(100)
 
 Compare two `Uint8Arrays`
 
-## Example
+### Example
 
 ```ts
 import { compare } from 'uint8arrays/compare'
@@ -83,7 +83,7 @@ Concatenate one or more `Uint8Array`s and return a `Uint8Array` with their conte
 
 If you know the length of the arrays, pass it as a second parameter, otherwise it will be calculated by traversing the list of arrays.
 
-## Example
+### Example
 
 ```ts
 import { concat } from 'uint8arrays/concat'
@@ -103,7 +103,7 @@ console.info(all)
 
 Returns true if the two arrays are the same array or if they have the same length and contents.
 
-## Example
+### Example
 
 ```ts
 import { equals } from 'uint8arrays/equals'
@@ -123,7 +123,7 @@ Returns a new `Uint8Array` created from the passed string and interpreted as the
 
 Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
 
-## Example
+### Example
 
 ```ts
 import { fromString } from 'uint8arrays/from-string'
@@ -140,7 +140,7 @@ Returns a string created from the passed `Uint8Array` in the passed encoding.
 
 Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
 
-## Example
+### Example
 
 ```ts
 import { toString } from 'uint8arrays/to-string'
@@ -160,7 +160,7 @@ The types of these two values have diverged in `typescript@5.7` or later.
 Some APIs require `Uint8Array`s backed by `ArrayBuffer`s specifically so call
 `withArrayBuffer` to ensure your `Uint8Array`s are backed the correct type.
 
-## Example
+### Example
 
 ```ts
 import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
@@ -178,7 +178,7 @@ console.info(arr2.buffer.constructor) // [Function: ArrayBuffer]
 
 Returns a `Uint8Array` containing `a` and `b` xored together.
 
-## Example
+### Example
 
 ```ts
 import { xor } from 'uint8arrays/xor'
@@ -190,7 +190,7 @@ console.info(xor(Uint8Array.from([1, 0]), Uint8Array.from([0, 1]))) // Uint8Arra
 
 Compares the distances between two xor `Uint8Array`s.
 
-## Example
+### Example
 
 ```ts
 import { xor } from 'uint8arrays/xor'

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Since Node.js `Buffer`s are also `Uint8Array`s, it falls back to `Buffer` intern
 
 Create a new `Uint8Array`. When running under Node.js, `Buffer` will be used in preference to `Uint8Array`.
 
-### Example
+## Example
 
-```js
+```ts
 import { alloc } from 'uint8arrays/alloc'
 
 const buf = alloc(100)
@@ -46,9 +46,9 @@ Create a new `Uint8Array`. When running under Node.js, `Buffer` will be used in 
 
 On platforms that support it, memory referenced by the returned `Uint8Array` will not be initialized.
 
-### Example
+## Example
 
-```js
+```ts
 import { allocUnsafe } from 'uint8arrays/alloc'
 
 const buf = allocUnsafe(100)
@@ -58,9 +58,9 @@ const buf = allocUnsafe(100)
 
 Compare two `Uint8Arrays`
 
-### Example
+## Example
 
-```js
+```ts
 import { compare } from 'uint8arrays/compare'
 
 const arrays = [
@@ -83,9 +83,9 @@ Concatenate one or more `Uint8Array`s and return a `Uint8Array` with their conte
 
 If you know the length of the arrays, pass it as a second parameter, otherwise it will be calculated by traversing the list of arrays.
 
-### Example
+## Example
 
-```js
+```ts
 import { concat } from 'uint8arrays/concat'
 
 const arrays = [
@@ -103,9 +103,9 @@ console.info(all)
 
 Returns true if the two arrays are the same array or if they have the same length and contents.
 
-### Example
+## Example
 
-```js
+```ts
 import { equals } from 'uint8arrays/equals'
 
 const a = Uint8Array.from([0, 1, 2])
@@ -123,9 +123,9 @@ Returns a new `Uint8Array` created from the passed string and interpreted as the
 
 Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
 
-### Example
+## Example
 
-```js
+```ts
 import { fromString } from 'uint8arrays/from-string'
 
 console.info(fromString('hello world')) // Uint8Array[104, 101 ...
@@ -140,9 +140,9 @@ Returns a string created from the passed `Uint8Array` in the passed encoding.
 
 Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
 
-### Example
+## Example
 
-```js
+```ts
 import { toString } from 'uint8arrays/to-string'
 
 console.info(toString(Uint8Array.from([104, 101...]))) // 'hello world'
@@ -151,13 +151,36 @@ console.info(toString(Uint8Array.from([0, 1, 2...]), 'base64')) // 'AAECA6q7zA'
 console.info(toString(Uint8Array.from([48, 49, 50...]), 'ascii')) // '01234'
 ```
 
+## withArrayBuffer(buf)
+
+`Uint8Array`s can be backed by an `ArrayBuffer` or a `SharedArrayBuffer`.
+
+The types of these two values have diverged in `typescript@5.7` or later.
+
+Some APIs require `Uint8Array`s backed by `ArrayBuffer`s specifically so call
+`withArrayBuffer` to ensure your `Uint8Array`s are backed the correct type.
+
+## Example
+
+```ts
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
+
+const buf = new SharedArrayBuffer(10)
+const arr = new Uint8Array(buf, 0, buf.byteLength)
+
+const arr2 = withArrayBuffer(arr)
+
+console.info(arr.buffer.constructor) // [Function: SharedArrayBuffer]
+console.info(arr2.buffer.constructor) // [Function: ArrayBuffer]
+```
+
 ## xor(a, b)
 
 Returns a `Uint8Array` containing `a` and `b` xored together.
 
-### Example
+## Example
 
-```js
+```ts
 import { xor } from 'uint8arrays/xor'
 
 console.info(xor(Uint8Array.from([1, 0]), Uint8Array.from([0, 1]))) // Uint8Array[1, 1]
@@ -167,7 +190,7 @@ console.info(xor(Uint8Array.from([1, 0]), Uint8Array.from([0, 1]))) // Uint8Arra
 
 Compares the distances between two xor `Uint8Array`s.
 
-### Example
+## Example
 
 ```ts
 import { xor } from 'uint8arrays/xor'

--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
       "import": "./dist/src/to-string.js",
       "module-sync": "./dist/src/to-string.js"
     },
+    "./with-array-buffer": {
+      "types": "./dist/src/with-array-buffer.d.ts",
+      "import": "./dist/src/with-array-buffer.js",
+      "module-sync": "./dist/src/with-array-buffer.js"
+    },
     "./xor": {
       "types": "./dist/src/xor.d.ts",
       "import": "./dist/src/xor.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@
  *
  * Create a new `Uint8Array`. When running under Node.js, `Buffer` will be used in preference to `Uint8Array`.
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { alloc } from 'uint8arrays/alloc'
  *
  * const buf = alloc(100)
@@ -25,9 +25,9 @@
  *
  * On platforms that support it, memory referenced by the returned `Uint8Array` will not be initialized.
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { allocUnsafe } from 'uint8arrays/alloc'
  *
  * const buf = allocUnsafe(100)
@@ -37,9 +37,9 @@
  *
  * Compare two `Uint8Arrays`
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { compare } from 'uint8arrays/compare'
  *
  * const arrays = [
@@ -62,9 +62,9 @@
  *
  * If you know the length of the arrays, pass it as a second parameter, otherwise it will be calculated by traversing the list of arrays.
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { concat } from 'uint8arrays/concat'
  *
  * const arrays = [
@@ -82,9 +82,9 @@
  *
  * Returns true if the two arrays are the same array or if they have the same length and contents.
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { equals } from 'uint8arrays/equals'
  *
  * const a = Uint8Array.from([0, 1, 2])
@@ -102,9 +102,9 @@
  *
  * Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { fromString } from 'uint8arrays/from-string'
  *
  * console.info(fromString('hello world')) // Uint8Array[104, 101 ...
@@ -119,9 +119,9 @@
  *
  * Supports `utf8` and any of the [multibase encodings](https://github.com/multiformats/multibase/blob/master/multibase.csv) as implemented by the [multiformats module](https://www.npmjs.com/package/multiformats).
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { toString } from 'uint8arrays/to-string'
  *
  * console.info(toString(Uint8Array.from([104, 101...]))) // 'hello world'
@@ -130,13 +130,36 @@
  * console.info(toString(Uint8Array.from([48, 49, 50...]), 'ascii')) // '01234'
  * ```
  *
+ * ## withArrayBuffer(buf)
+ *
+ * `Uint8Array`s can be backed by an `ArrayBuffer` or a `SharedArrayBuffer`.
+ *
+ * The types of these two values have diverged in `typescript@5.7` or later.
+ *
+ * Some APIs require `Uint8Array`s backed by `ArrayBuffer`s specifically so call
+ * `withArrayBuffer` to ensure your `Uint8Array`s are backed the correct type.
+ *
+ * @example
+ *
+ * ```ts
+ * import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
+ *
+ * const buf = new SharedArrayBuffer(10)
+ * const arr = new Uint8Array(buf, 0, buf.byteLength)
+ *
+ * const arr2 = withArrayBuffer(arr)
+ *
+ * console.info(arr.buffer.constructor) // [Function: SharedArrayBuffer]
+ * console.info(arr2.buffer.constructor) // [Function: ArrayBuffer]
+ * ```
+ *
  * ## xor(a, b)
  *
  * Returns a `Uint8Array` containing `a` and `b` xored together.
  *
- * ### Example
+ * @example
  *
- * ```js
+ * ```ts
  * import { xor } from 'uint8arrays/xor'
  *
  * console.info(xor(Uint8Array.from([1, 0]), Uint8Array.from([0, 1]))) // Uint8Array[1, 1]
@@ -146,7 +169,7 @@
  *
  * Compares the distances between two xor `Uint8Array`s.
  *
- * ### Example
+ * @example
  *
  * ```ts
  * import { xor } from 'uint8arrays/xor'

--- a/src/with-array-buffer.ts
+++ b/src/with-array-buffer.ts
@@ -1,0 +1,16 @@
+function isArrayBufferBacked (arr: Uint8Array): arr is Uint8Array<ArrayBuffer> {
+  return arr.buffer instanceof ArrayBuffer
+}
+
+/**
+ * If the passed `arr` is of type `Uint8Array<ArrayBuffer>`, it is returned
+ * unchanged, otherwise a new `Uint8Array<ArrayBuffer>` is created with the
+ * data being a copy of the data in the passed `arr`.
+ */
+export function withArrayBuffer (arr: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (isArrayBufferBacked(arr)) {
+    return arr
+  }
+
+  return arr.slice()
+}

--- a/test/with-array-buffer.spec.ts
+++ b/test/with-array-buffer.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from 'aegir/chai'
+import { withArrayBuffer } from '../src/with-array-buffer.ts'
+
+describe('Uint8Array withArrayBuffer', () => {
+  it('should return the original array', () => {
+    const arr = new Uint8Array(10)
+
+    const transformed = withArrayBuffer(arr)
+    expect(transformed).to.equal(arr)
+  })
+
+  it('should return a copy of original array', function () {
+    if (global.SharedArrayBuffer == null) {
+      return this.skip()
+    }
+
+    const buf = new SharedArrayBuffer(10)
+    const arr = new Uint8Array(buf, 0, buf.byteLength)
+    expect(arr.buffer).to.be.an.instanceOf(SharedArrayBuffer)
+
+    const transformed = withArrayBuffer(arr)
+    expect(transformed).to.not.equal(arr)
+    expect(transformed).to.deep.equal(arr)
+    expect(transformed).to.be.an.instanceOf(Uint8Array)
+    expect(transformed.buffer).to.be.an.instanceOf(ArrayBuffer)
+    expect(transformed).to.equalBytes(arr)
+  })
+})


### PR DESCRIPTION
Adds a function to ensure that a `Uint8Array` is backed by an `ArrayBuffer`
instance which is required by several APIs after `typescript@5.7`.